### PR TITLE
Try/Catch JSON formatting of response

### DIFF
--- a/lib/foodlogiq-client/foodlogiq-connection.js
+++ b/lib/foodlogiq-client/foodlogiq-connection.js
@@ -48,7 +48,13 @@ exports.init = function(accessToken) {
             winston.error('error accessing information from API');
             winston.error(res.statusCode);
             winston.error(response);
-            callback('API request got status code: ' + res.statusCode + '.  ' + response, JSON.parse(response));
+            var jsonresponse = null;
+            try {
+              jsonresponse = JSON.parse(response);
+            } catch(err){
+              jsonresponse = response;
+            }
+            callback('API request got status code: ' + res.statusCode + '.  ' + response, jsonresponse);
           }
         });
       });


### PR DESCRIPTION
Added a try/catch statement to the parsing of the server response in foodlogiq-client. If the response is not JSON formatted, the client throws an uncatchable error. With this code, the error is much more likely to be properly passed on to the next function.
