### PR TITLE
Stock Recovery Chat

### DIFF
--- a/lib/foodlogiq-client/stock-recoveries.js
+++ b/lib/foodlogiq-client/stock-recoveries.js
@@ -28,12 +28,17 @@ module.exports = function(conn) {
     delete: function(businessId, stockRecoveryId, callback){
       conn.delete('/businesses/'+businessId+'/stockRecoveries/'+stockRecoveryId, callback);
     },
+    
     addComment: function(businessId, stockRecoveryId, locationId, comment, callback){
       conn.put('/businesses/'+businessId+'/stockRecoveries/'+stockRecoveryId+'/addComment/'+locationId, comment, callback);
     },
 
     updateViewed: function(businessId, stockRecoveryId, locationId, viewed, callback){
       conn.put('/businesses/'+businessId+'/stockRecoveries/'+stockRecoveryId+'/updateViewed/'+locationId, viewed, callback);
+    },
+    
+    addUserIdToComments: function(businessId, stockRecoveryId, locationId, data, callback){
+      conn.put('/businesses/'+businessId+'/stockRecoveries/'+stockRecoveryId+'/addUserIdToComments/'+locationId, data, callback);
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foodlogiq-client",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "Wrapper around FLQ services.",
   "keywords": [
     "foodlogiq",


### PR DESCRIPTION
Added, a new route to node to handle updating the viewedBy array on stock recovery comments.

Three applications need the stock-recovery-chat branch merged in. Node, API, and vis-investigations.
